### PR TITLE
stop server if couldn't start properly

### DIFF
--- a/node-registrar/cmds/main.go
+++ b/node-registrar/cmds/main.go
@@ -96,7 +96,7 @@ func Run() error {
 	quit := make(chan os.Signal, 1)
 	signal.Notify(quit, os.Interrupt, syscall.SIGTERM)
 
-	log.Info().Msg("server is running on port :8080")
+	log.Info().Msgf("server is running on port :%d", f.serverPort)
 
 	err = s.Run(quit, fmt.Sprintf("%s:%d", f.domain, f.serverPort))
 	if err != nil {

--- a/node-registrar/pkg/server/server.go
+++ b/node-registrar/pkg/server/server.go
@@ -5,6 +5,7 @@ import (
 	"net/http"
 	"os"
 	"sync"
+	"syscall"
 
 	"github.com/gin-gonic/gin"
 	"github.com/rs/zerolog/log"
@@ -48,6 +49,9 @@ func (s Server) Run(quit chan os.Signal, addr string) error {
 	}()
 
 	err := server.ListenAndServe()
+	if err != nil {
+		quit <- syscall.SIGINT
+	}
 	wg.Wait()
 
 	return err


### PR DESCRIPTION
### Description

fix server not stopping on having invalid host or port

### Changes

- fix `server is running on port :8080` msg
- fix server not stopping if it couldn't run properly. 

### Related Issues

- #21 

### Checklist

- [ ] Tests included
- [ ] Build pass
- [ ] Documentation
- [ ] Code format and docstring
