### PR TITLE
update node ips type to []string

### DIFF
--- a/node-registrar/pkg/db/db.go
+++ b/node-registrar/pkg/db/db.go
@@ -71,19 +71,6 @@ func openDatabase(c Config) (db Database, err error) {
 	return Database{gormDB, dsn}, nil
 }
 
-func (db Database) autoMigrate() error {
-	if err := db.gormDB.AutoMigrate(
-		&Account{},
-		&Farm{},
-		&Node{},
-		&UptimeReport{},
-		&ZosVersion{},
-	); err != nil {
-		return errors.Wrap(err, "failed to migrate tables")
-	}
-	return nil
-}
-
 func (c Config) Validate() error {
 	if strings.TrimSpace(c.PostgresHost) == "" {
 		return errors.New("invalid postgres host, postgres host should not be empty")

--- a/node-registrar/pkg/db/migrate.go
+++ b/node-registrar/pkg/db/migrate.go
@@ -7,10 +7,6 @@ import (
 )
 
 func (db Database) autoMigrate() error {
-	if err := db.migrateNodes(); err != nil {
-		return err
-	}
-
 	if err := db.gormDB.AutoMigrate(
 		&Account{},
 		&Farm{},
@@ -20,6 +16,11 @@ func (db Database) autoMigrate() error {
 	); err != nil {
 		return errors.Wrap(err, "failed to migrate tables")
 	}
+
+	if err := db.migrateNodes(); err != nil {
+		return err
+	}
+
 	return nil
 }
 

--- a/node-registrar/pkg/db/migrate.go
+++ b/node-registrar/pkg/db/migrate.go
@@ -1,0 +1,90 @@
+package db
+
+import (
+	"strings"
+
+	"github.com/pkg/errors"
+)
+
+func (db Database) autoMigrate() error {
+	if err := db.migrateNodes(); err != nil {
+		return err
+	}
+
+	if err := db.gormDB.AutoMigrate(
+		&Account{},
+		&Farm{},
+		&Node{},
+		&UptimeReport{},
+		&ZosVersion{},
+	); err != nil {
+		return errors.Wrap(err, "failed to migrate tables")
+	}
+	return nil
+}
+
+func (db Database) migrateNodes() error {
+	// if nodes are already migrated skip migration
+	if result := db.gormDB.First(&Node{}); result.Error == nil {
+		return nil
+	}
+
+	type oldInterface struct {
+		Name string `json:"name"`
+		Mac  string `json:"mac"`
+		IPs  string `json:"ips"`
+	}
+
+	type nodeType struct {
+		NodeID uint64 `json:"node_id" gorm:"primaryKey;autoIncrement"`
+		FarmID uint64 `json:"farm_id" gorm:"not null;check:farm_id> 0;foreignKey:FarmID;references:FarmID;constraint:OnDelete:RESTRICT"`
+		TwinID uint64 `json:"twin_id" gorm:"not null;unique;check:twin_id > 0;foreignKey:TwinID;references:TwinID;constraint:OnDelete:RESTRICT"`
+
+		Location Location `json:"location" gorm:"not null;type:json;serializer:json"`
+
+		Resources    Resources      `json:"resources" gorm:"not null;type:json;serializer:json"`
+		Interfaces   []oldInterface `gorm:"not null;type:json;serializer:json"`
+		SecureBoot   bool           `json:"secure_boot"`
+		Virtualized  bool           `json:"virtualized"`
+		SerialNumber string         `json:"serial_number"`
+
+		Approved bool `json:"approved"`
+	}
+
+	var nodes []nodeType
+	result := db.gormDB.Model(&Node{}).Find(&nodes)
+	if result.Error != nil {
+		return result.Error
+	}
+
+	for _, node := range nodes {
+		var interfaces []Interface
+		for _, i := range node.Interfaces {
+			ips := strings.Split(i.IPs, "/")
+			newInterface := Interface{
+				Name: i.Name,
+				Mac:  i.Mac,
+				IPs:  ips,
+			}
+			interfaces = append(interfaces, newInterface)
+		}
+
+		updatedNode := Node{
+			NodeID:      node.NodeID,
+			FarmID:      node.FarmID,
+			TwinID:      node.TwinID,
+			Location:    node.Location,
+			Resources:   node.Resources,
+			Interfaces:  interfaces,
+			SecureBoot:  node.SecureBoot,
+			Virtualized: node.Virtualized,
+			Approved:    node.Approved,
+		}
+
+		err := db.gormDB.Model(&Node{}).Where("node_id = ?", node.NodeID).Updates(updatedNode).Error
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}

--- a/node-registrar/pkg/db/models.go
+++ b/node-registrar/pkg/db/models.go
@@ -69,9 +69,9 @@ type ZosVersion struct {
 }
 
 type Interface struct {
-	Name string `json:"name"`
-	Mac  string `json:"mac"`
-	IPs  string `json:"ips"`
+	Name string   `json:"name"`
+	Mac  string   `json:"mac"`
+	IPs  []string `json:"ips" gorm:"not null,type:text[];default:'{}'"`
 }
 
 type Resources struct {


### PR DESCRIPTION
### Description

ips in node interfaces are created as strings, we need to update them to []string to match zos3 nodes

### Changes

- update ips to be []string
- add migration code to update old nodes if not updated.

### Related Issues

List of related issues

### Checklist

- [ ] Tests included
- [ ] Build pass
- [ ] Documentation
- [ ] Code format and docstring
