### PR TITLE
make registrar backward compatible with interface.ips

### DIFF
--- a/node-registrar/Makefile
+++ b/node-registrar/Makefile
@@ -1,5 +1,5 @@
 run:
-	go run cmds/main.go --postgres-host localhost --postgres-port 5432 --postgres-db postgres --postgres-user postgres --postgres-password password --domain localhost --server-port 8080
+	go run cmds/main.go --postgres-host localhost --postgres-port 5432 --postgres-db postgres --postgres-user postgres --postgres-password password --domain 0.0.0.0 --server-port 8080
 
 start-postgres:
 	docker run --name postgres -e POSTGRES_USER=postgres -e POSTGRES_PASSWORD=password -e POSTGRES_DB=postgres -p 5432:5432 -d postgres

--- a/node-registrar/client/node.go
+++ b/node-registrar/client/node.go
@@ -71,7 +71,7 @@ func (c *RegistrarClient) registerNode(node Node) (nodeID uint64, err error) {
 
 		resp, err := c.httpClient.Do(req)
 		if err != nil {
-			return nodeID, errors.Wrap(err, "failed to send request to registrer the node")
+			return nodeID, errors.Wrap(err, "failed to send request to registrar the node")
 		}
 
 		if resp == nil {

--- a/node-registrar/pkg/db/interface_test.go
+++ b/node-registrar/pkg/db/interface_test.go
@@ -1,0 +1,100 @@
+package db
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+func TestInterfaceUnmarshalJSON_OldFormat(t *testing.T) {
+	// Test old format where ips is a string with "/" separators
+	jsonData := []byte(`{
+		"name": "eth0",
+		"mac": "00:11:22:33:44:55",
+		"ips": "192.168.1.1/10.0.0.1"
+	}`)
+
+	var iface Interface
+	err := json.Unmarshal(jsonData, &iface)
+	if err != nil {
+		t.Fatalf("Failed to unmarshal old format: %v", err)
+	}
+
+	if iface.Name != "eth0" {
+		t.Errorf("Expected name 'eth0', got '%s'", iface.Name)
+	}
+	if len(iface.IPs) != 2 {
+		t.Fatalf("Expected 2 IPs, got %d", len(iface.IPs))
+	}
+	if iface.IPs[0] != "192.168.1.1" {
+		t.Errorf("Expected first IP '192.168.1.1', got '%s'", iface.IPs[0])
+	}
+	if iface.IPs[1] != "10.0.0.1" {
+		t.Errorf("Expected second IP '10.0.0.1', got '%s'", iface.IPs[1])
+	}
+}
+
+func TestInterfaceUnmarshalJSON_NewFormat(t *testing.T) {
+	// Test new format where ips is an array of strings
+	jsonData := []byte(`{
+		"name": "eth0",
+		"mac": "00:11:22:33:44:55",
+		"ips": ["192.168.1.1", "10.0.0.1"]
+	}`)
+
+	var iface Interface
+	err := json.Unmarshal(jsonData, &iface)
+	if err != nil {
+		t.Fatalf("Failed to unmarshal new format: %v", err)
+	}
+
+	if iface.Name != "eth0" {
+		t.Errorf("Expected name 'eth0', got '%s'", iface.Name)
+	}
+	if len(iface.IPs) != 2 {
+		t.Fatalf("Expected 2 IPs, got %d", len(iface.IPs))
+	}
+	if iface.IPs[0] != "192.168.1.1" {
+		t.Errorf("Expected first IP '192.168.1.1', got '%s'", iface.IPs[0])
+	}
+	if iface.IPs[1] != "10.0.0.1" {
+		t.Errorf("Expected second IP '10.0.0.1', got '%s'", iface.IPs[1])
+	}
+}
+
+func TestInterfaceUnmarshalJSON_EmptyString(t *testing.T) {
+	// Test empty string for ips
+	jsonData := []byte(`{
+		"name": "eth0",
+		"mac": "00:11:22:33:44:55",
+		"ips": ""
+	}`)
+
+	var iface Interface
+	err := json.Unmarshal(jsonData, &iface)
+	if err != nil {
+		t.Fatalf("Failed to unmarshal empty string: %v", err)
+	}
+
+	if len(iface.IPs) != 0 {
+		t.Errorf("Expected 0 IPs for empty string, got %d", len(iface.IPs))
+	}
+}
+
+func TestInterfaceUnmarshalJSON_EmptyArray(t *testing.T) {
+	// Test empty array for ips
+	jsonData := []byte(`{
+		"name": "eth0",
+		"mac": "00:11:22:33:44:55",
+		"ips": []
+	}`)
+
+	var iface Interface
+	err := json.Unmarshal(jsonData, &iface)
+	if err != nil {
+		t.Fatalf("Failed to unmarshal empty array: %v", err)
+	}
+
+	if len(iface.IPs) != 0 {
+		t.Errorf("Expected 0 IPs for empty array, got %d", len(iface.IPs))
+	}
+}

--- a/node-registrar/pkg/db/models.go
+++ b/node-registrar/pkg/db/models.go
@@ -1,7 +1,9 @@
 package db
 
 import (
+	"encoding/json"
 	"errors"
+	"strings"
 	"time"
 
 	"github.com/lib/pq"
@@ -82,6 +84,49 @@ type Interface struct {
 	Name string   `json:"name"`
 	Mac  string   `json:"mac"`
 	IPs  []string `json:"ips" gorm:"not null,type:text[];default:'{}'"`
+}
+
+// UnmarshalJSON implements custom unmarshaling to handle both old format (ips as string)
+// and new format (ips as []string) for backward compatibility
+func (i *Interface) UnmarshalJSON(data []byte) error {
+	type Alias Interface
+	aux := &struct {
+		IPs interface{} `json:"ips"`
+		*Alias
+	}{
+		Alias: (*Alias)(i),
+	}
+
+	if err := json.Unmarshal(data, &aux); err != nil {
+		return err
+	}
+
+	// Handle different types for IPs field
+	switch v := aux.IPs.(type) {
+	case string:
+		// Old format: "ip1/ip2/ip3"
+		if v == "" {
+			i.IPs = []string{}
+		} else {
+			i.IPs = strings.Split(v, "/")
+		}
+	case []interface{}:
+		// New format from JSON: ["ip1", "ip2", "ip3"]
+		i.IPs = make([]string, 0, len(v))
+		for _, ip := range v {
+			if str, ok := ip.(string); ok {
+				i.IPs = append(i.IPs, str)
+			}
+		}
+	case []string:
+		// New format: already in correct format
+		i.IPs = v
+	default:
+		// Handle nil or any other unexpected type
+		i.IPs = []string{}
+	}
+
+	return nil
 }
 
 type Resources struct {


### PR DESCRIPTION
### Description

make registrar backward compatible with interface.ips
### Changes

List of changes this PR includes

### Related Issues
https://github.com/threefoldtech/zos/issues/2629

### Checklist

- [ ] Tests included
- [ ] Build pass
- [ ] Documentation
- [ ] Code format and docstring
